### PR TITLE
読書時間の登録機能の実装

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -4,19 +4,23 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\MemoRequest;
-use App\Models\Kind;
 use App\Models\Memo;
+use App\Models\Kind;
+use App\Models\ReadTime;
 
 class MemoController extends Controller
 {
     public function show(Memo $memo, Kind $kind, ReadTime $read_time)
     {
-        $fake_array = array('本が登録されていません');
-        $books = $kind->getOrderByPoint();
-        
+        $read_times = array(
+                    'today' => $read_time->getTodayReadTime(),
+                    'week' => $read_time->getWeekReadTime(),
+                    );
+                    
         return view('home.mypage')->with([
             'memos' => $memo->getPaginateByLimit(),
-            'book_list' => $books,
+            'book_list' => $kind->getOrderByPoint(),
+            'read_times' => $read_times,
             ]);
     }
     

--- a/app/Http/Controllers/ReadTimeController.php
+++ b/app/Http/Controllers/ReadTimeController.php
@@ -3,8 +3,18 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\ReadTimeRequest;
+use App\Models\ReadTime;
+
 
 class ReadTimeController extends Controller
 {
-    //
+    public function store(ReadTimeRequest $request, ReadTime $read_time)
+    {
+        $input = $request['ReadTime'];
+        $input['user_id'] = Auth::user()->id;
+        $read_time->fill($input)->save();
+        return redirect('/mypage');
+    }
 }

--- a/app/Http/Requests/ReadTimeRequest.php
+++ b/app/Http/Requests/ReadTimeRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReadTimeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'ReadTime.read_time' => 'required|integer|between:0,24',
+        ];
+    }
+}

--- a/app/Models/Kind.php
+++ b/app/Models/Kind.php
@@ -57,25 +57,16 @@ class Kind extends Model
         $user = Auth::user()->id;
         
         $register_books = Book::get()->where('user_id',$user) ?? 0;
-        
         $comic = $this::find(1);
-        
         $novel = $this::find(2);
         
-        
-        
         $all_register_books = $register_books->count() ?? 0;
-        
         $comics = $comic->books()->with('kind')->where('user_id',$user)->get()->count() ?? 0;
-        
         $novels = $novel->books()->with('kind')->where('user_id',$user)->get()->count() ?? 0;
         
         $total_books = $register_books->sum('volume') ?? 0;
-        
         $total_comics = $comic->books()->with('kind')->where('user_id',$user)->get()->sum('volume') ?? 0;
-        
         $total_novels = $novel->books()->with('kind')->where('user_id',$user)->get()->sum('volume') ?? 0;
-        
         
         return $book_data = array(
                             'all_register_books' => $all_register_books,

--- a/app/Models/ReadTime.php
+++ b/app/Models/ReadTime.php
@@ -5,13 +5,31 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
 
 class ReadTime extends Model
 {
     use HasFactory;
     
+    protected $fillable = [
+        'read_time',
+        'user_id',
+        ];
+    
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+    
+    public function getWeekReadTime()
+    {
+        $user = Auth::user()->id;
+        return $this->where('user_id',$user)->orderBy('created_at','DESC')->paginate(7);
+    }
+    
+    public function getTodayReadTime()
+    {
+        $user = Auth::user()->id;
+        return $this->where('user_id',$user)->whereDay('created_at',date('d'))->orderBy('created_at','DESC')->first();
     }
 }

--- a/resources/views/home/mypage.blade.php
+++ b/resources/views/home/mypage.blade.php
@@ -40,15 +40,32 @@
             </div>
             
             <div>
-                <h2>一週間の読書量</h2>
+                <h2>一週間の読書時間</h2>
                 <div>
-                    <form 
+                    @if($read_times['week'])
+                        @foreach($read_times['week'] as $read_time)
+                            <p>{{$read_time->read_time}}</p>
+                        @endforeach
+                    @else
+                        <p>読書時間が登録されていません</p>
+                    @endif
+                </div>
+                <div>
+                    <form action="/mypage/ReadTime" method="POST">
+                        @csrf
+                        <div>
+                            <h2>今日の読書時間</h2>
+                            <input type="number" name="ReadTime[read_time]" placeholder="{{$read_times['today']->read_time ?? '0'}}" min="0" max="24"/>
+                            <p class="ReadTime__error" style="color:red">{{$errors->first('ReadTime.read_time')}}</p>
+                        </div>
+                        <input type="submit" value="追加"/>
+                    </form>
                 </div>
             </div>
             
             <div>
                 <p>今日は</p>
-                <p>DateTime</p>
+                <p>{{date('m-d')}}</p>
             </div>
             <div>
                 <h2>本の評価</h2>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\BookController;
 use App\Http\Controllers\KindController;
 use App\Http\Controllers\MemoController;
+use App\Http\Controllers\ReadTimeController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -59,6 +60,11 @@ Route::controller(MemoController::class)->middleware(['auth'])->group(function()
     Route::delete('/mypage/memos/{memo}','delete')->name('memo_delete');
     Route::get('/mypage/memos/{memo}/edit','edit')->name('memo_edit');
 });
+
+Route::controller(ReadTimeController::class)->middleware(['auth'])->group(function(){
+    Route::post('/mypage/ReadTime','store')->name('ReadTime_store');
+});
+
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
・マイページ内に読書時間を入力できるフォームを記述
・フォームで登録処理を起動させるためにルーティングを記述
・ReadTimeコントローラーに登録処理を記述
・ユーザーが持つ読書時間を一日（今日）の分と一週間分と分けて取得できるように記述
・Kindモデルの改行の削除を行い見やすいように整理