### PR TITLE
ユーザーの本棚やマイページからお気に入り、その解除を追加

### DIFF
--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -3,33 +3,9 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use App\Models\User;
 use App\Models\Favorite;
 
 class FavoriteController extends Controller
 {
-    public function show(User $user)
-    {
-        
-        return view('home.othershelf')->with([
-            'favorited_users' => $user->getFavoriteUser(),
-            'unFavorite_users' => $user->getNotFavoriteUser(),
-            ]);
-    }
-    
-    public function favorite(Request $request, Favorite $favorite, User $user)
-    {
-        $input = $request['favorite'];
-        $input['registing_id'] = Auth::user()->id;
-        $favorite->fill($input)->save();
-        
-        return redirect('/othershelf');
-    }
-    
-    public function unFavorite(Favorite $favorite)
-    {
-        $favorite->delete();
-        return redirect('/othershelf');
-    }
+    //
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+
+class UserController extends Controller
+{
+    public function show(User $user)
+    {
+        
+        return view('home.othershelf')->with([
+            'users' => $user->getUsers(),
+            'favorited_users' => $user->getFavoriteUsers(),
+            'check' => $user,
+            ]);
+    }
+    
+    public function favorite(User $user)
+    {
+        $user->attachFavorite($user->id);
+        return redirect('/othershelf');
+    }
+    
+    public function unFavorite(User $user)
+    {
+        $user->detachFavorite($user->id);
+        return redirect('/othershelf');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,7 @@ class User extends Authenticatable
     ];
     
     
+    
     public function books()
     {
         return $this->hasMany(Book::class);
@@ -69,27 +70,42 @@ class User extends Authenticatable
     
     public function favorites()
     {
-        return $this->belongsToMany(User::class,'favorites','registered_id','registing_id');
+        return $this->belongsToMany(User::class,'favorites','registered_id','registing_id')->withPivot('id','registered_id','registing_id');
     }
     
     
-    public function getFavoriteUser()
+    
+    public function getUsers()
     {
-        $favorite_users = Auth::user()->favoriteUsers()->paginate(10,['*'],'Favorite-page');
+        return Auth::user()->whereNot('id',Auth::user()->id)->paginate(10,['*'],'user-page');
+    }
+    
+    public function getFavoriteUsers()
+    {
+        return $favorite_users = Auth::user()->favoriteUsers()->paginate(10,['*'],'Favorite-page');;
+    }
+    
+    public function checkFavorite($check_user)
+    {
+        $check = Auth::user()->favoriteUsers()->where([['registing_id', Auth::user()->id],['registered_id', $check_user]])->first();
         
-        return $favorite_users;
-    }
-    
-    public function getNotFavoriteUser()
-    {
-        $favorited_users = $this->getFavoriteUser();
-        $my_id = Auth::user()->id;
-    
-        $favorited_users_id = array($my_id);
-        foreach($favorited_users as $favorited_user){
-            $favorited_users_id[] = $favorited_user->id;
+        if($check){
+            return true;
+        }else{
+            return false;
         }
-        
-        return $this->whereNotIn('id',$favorited_users_id)->paginate(10,['*'],'unFavorite-page');
+    }
+    
+    public function attachFavorite($user_id) 
+    {
+        $registeing_user = $this::find(Auth::user()->id);
+        return $registeing_user->favoriteUsers()->attach($user_id);
+    }
+
+    // フォロー解除する
+    public function detachFavorite($user_id)
+    {
+        $registeing_user = $this::find(Auth::user()->id);
+        return $registeing_user->favoriteUsers()->detach($user_id);
     }
 }

--- a/resources/views/home/mypage.blade.php
+++ b/resources/views/home/mypage.blade.php
@@ -114,8 +114,27 @@
                 <div>
                     <p><a href="/othershelf/users/{{$user->id}}/1">本棚へ</a></p>
                 </div>
+                <div>
+                    @if($user->checkFavorite($user->id))
+                        <div>
+                            <form action="/othershelf/favorite/{{$user->id}}/detach" id="form_{{$user->id}}" method="POST">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" onclick="deletePost({{$user->id}})">お気に入り解除</button>
+                            </form>
+                        </div>
+                    @else
+                        <div>
+                            <form action="/othershelf/favorite/{{$user->id}}/attach" method="POST" name="{{$user->name}}フォーム">
+                                @csrf
+                                <input type="hidden" name="favorite[registered_id]" value="{{$user->id}}">
+                                <input type="submit" value="お気に入り"/>
+                            </form>
+                        </div>
+                    @endif
+                </div>
             @endif
-            
+        
             <p><a href="#">ページトップへ戻る</a></p>
         </center>
             

--- a/resources/views/home/myshelf.blade.php
+++ b/resources/views/home/myshelf.blade.php
@@ -89,6 +89,23 @@
                 <a href="/myshelf/books/register">本の登録</a>
             @else
                 <a href="/mypage/users/{{$user->id}}">マイページへ</a>
+                @if($user->checkFavorite($user->id))
+                        <div>
+                            <form action="/othershelf/favorite/{{$user->id}}/detach" id="form_{{$user->id}}" method="POST">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" onclick="deletePost({{$user->id}})">お気に入り解除</button>
+                            </form>
+                        </div>
+                    @else
+                        <div>
+                            <form action="/othershelf/favorite/{{$user->id}}/attach" method="POST" name="{{$user->name}}フォーム">
+                                @csrf
+                                <input type="hidden" name="favorite[registered_id]" value="{{$user->id}}">
+                                <input type="submit" value="お気に入り"/>
+                            </form>
+                        </div>
+                    @endif
             @endif
             <p><a href="#">ページトップへ戻る</a></p>
         </div>

--- a/resources/views/home/othershelf.blade.php
+++ b/resources/views/home/othershelf.blade.php
@@ -29,52 +29,32 @@
                 私の本棚
             </h2>
         </div>
+        <br/>
         <div>
             <h2>みんなの本棚</h2>
             <p>新たな出会いをあなたに</p>
         </div>
-        <div>
-            <div>
-                @foreach($unFavorite_users as $user)
-                    <div>
-                        <form action="/othershelf/favorite" method="POST" name="{{$user->name}}フォーム">
-                            @csrf
-                            <input type="hidden" name="favorite[registered_id]" value="{{$user->id}}">
-                            <p>{{$user->name}}</p>
-                            <p>
-                                <a href="/othershelf/users/{{$user->id}}/1">本棚へ</a>
-                                <a href="/mypage/users/{{$user->id}}">マイページへ</a>
-                            </p>
-                            <input type="submit" value="お気に入り"/>
-                        </form>
-                    </div>
-                @endforeach
-                <div class='paginate'>
-                    {{$unFavorite_users->links()}}
-                </div>
-            </div>
-        </div>
-        <br/>
-        
         <br/>
         <div>
             <div>
-                <p>-----------お気に入りユーザ----------</p>
+                <p>---------------------------お気に入りユーザ-----------------------</p>
             </div>
             <div>
             @if($favorited_users)
                 @foreach($favorited_users as $user)
                     <div>
-                    <form action="/othershelf/favorite/{{$user->pivot->id}}" id="form_{{$user->pivot->id}}" method="POST">
-                        @csrf
-                        @method('DELETE')
-                        <p>{{$user->name}}</p>
-                        <p>
-                            <a href="/othershelf/users/{{$user->id}}/1">本棚へ</a>
-                            <a href="/mypage/users/{{$user->id}}">マイページへ</a>
-                        </p>
-                        <button type="submit" onclick="deletePost({{$user->id}})">お気に入り解除</button>
-                    </form>
+                        <div>==================================</div>
+                        <form action="/othershelf/favorite/{{$user->id}}/detach" id="form_{{$user->pivot->id}}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <p>{{$user->name}}</p>
+                            <p>
+                                <a href="/othershelf/users/{{$user->id}}/1">本棚へ</a>
+                                <a href="/mypage/users/{{$user->id}}">マイページへ</a>
+                            </p>
+                            <button type="submit" onclick="deletePost({{$user->id}})">お気に入り解除</button>
+                        </form>
+                        <div>==================================</div>
                     </div>
                 @endforeach
                 <div class='paginate'>
@@ -85,7 +65,45 @@
             @endif
         </div>
             <div>
-                <p>------------------------------------</p>
+                <p>---------------------------------------------------------</p>
+            </div>
+        </div>
+        <br/>
+        <div>
+            <div>
+                @foreach($users as $user)
+                    <div>
+                        <p>----------------------------------------</p>
+                        <p>{{$user->name}}</p>
+                        <p>
+                            <a href="/othershelf/users/{{$user->id}}/1">本棚へ</a>
+                            <a href="/mypage/users/{{$user->id}}">マイページへ</a>
+                        </p>
+                    </div>
+                    @if($check->checkFavorite($user->id))
+                        <div>
+                            <form action="/othershelf/favorite/{{$user->id}}/detach" id="form_{{$user->id}}" method="POST">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" onclick="deletePost({{$user->id}})">お気に入り解除</button>
+                            </form>
+                        </div>
+                    @else
+                        <div>
+                            <form action="/othershelf/favorite/{{$user->id}}/attach" method="POST" name="{{$user->name}}フォーム">
+                                @csrf
+                                <input type="hidden" name="favorite[registered_id]" value="{{$user->id}}">
+                                <input type="submit" value="お気に入り"/>
+                            </form>
+                        </div>
+                    @endif
+                    <div>
+                        <p>-----------------------------------</p>
+                    </div>
+                @endforeach
+                <div class='paginate'>
+                    {{$users->links()}}
+                </div>
             </div>
         </div>
         <br/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,7 @@ use App\Http\Controllers\BookController;
 use App\Http\Controllers\KindController;
 use App\Http\Controllers\MemoController;
 use App\Http\Controllers\ReadTimeController;
-use App\Http\Controllers\FavoriteController;
+use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -64,10 +64,10 @@ Route::controller(ReadTimeController::class)->middleware(['auth'])->group(functi
     Route::put('/mypage/ReadTime/{read_time}','update')->name('ReadTime_update');
 });
 
-Route::controller(FavoriteController::class)->middleware(['auth'])->group(function(){
+Route::controller(UserController::class)->middleware(['auth'])->group(function(){
     Route::get('/othershelf','show')->name('othershelf');
-    Route::post('/othershelf/favorite','favorite')->name('user_favorite');
-    Route::delete('/othershelf/favorite/{favorite}','unFavorite')->name('user_favorite_delete');
+    Route::post('/othershelf/favorite/{user}/attach','favorite')->name('user_favorite');
+    Route::delete('/othershelf/favorite/{user}/detach','unFavorite')->name('user_favorite_delete');
 });
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
・中間テーブルであるfavoriteへの登録、解除をsave、deleteを使っていたものをattach、detachに変更
・上記の変更に伴うmypage、myshelf、othershelfのbladeファイルの修正
・Favoriteコントローラーを使っていたものFavoriteモデルを使わずUserモデルのみ使用していたためUserコントローラーに記述しなおしFavoriteコントローラーをコメントアウトした
・上記に伴うルーティングの変更、およびパスのfavoriteの暗黙の結合を解除し新しくuserで暗黙の結合を行った